### PR TITLE
perlfunc.pod: Correct getpwnam example

### DIFF
--- a/corpus/perlfunc.pod
+++ b/corpus/perlfunc.pod
@@ -2471,7 +2471,7 @@ for each field.  For example:
 
    use File::stat;
    use User::pwent;
-   $is_his = (stat($filename)->uid == pwent($whoever)->uid);
+   $is_theirs = (stat($filename)->uid == getpwnam($whoever)->uid);
 
 Even though it looks as though they're the same method calls (uid),
 they aren't, because a C<File::stat> object is different from


### PR DESCRIPTION
Fixes https://github.com/Perl/perl5/issues/21137